### PR TITLE
Fixed previous `state` running after next `state` starts 

### DIFF
--- a/src/StateMachine/init.lua
+++ b/src/StateMachine/init.lua
@@ -271,9 +271,7 @@ function StateMachine.new(initialState: string, states: {State}, initialData: {[
             return
         end
 
-        self._stateTrove:Add(
-            task.spawn(state.OnHeartbeat, state, self:GetData(), deltaTime)
-        )
+        self:_CallMethod(state, false, "OnHeartbeat", self:GetData(), deltaTime)
     end))
 
     self._trove:Add(self.StateChanged)
@@ -337,7 +335,7 @@ function StateMachine:ChangeData(index: string, newValue: any): ()
     self.Data[index] = newValue
 
     local state: State = self._States[self:GetCurrentState()]
-    task.spawn(state.OnDataChanged, state, self.Data, index, newValue, oldValue)
+    self:_CallMethod(state, false, "OnDataChanged", self.Data, index, newValue, oldValue)
     self.DataChanged:Fire(self.Data, index, newValue, oldValue)
 end
 
@@ -527,7 +525,7 @@ function StateMachine:_ChangeState(newState: string): ()
     task.defer(function()
         self:_CallTransitions(state, "OnEnter", self:GetData())
     end)
-    self._stateTrove:Add(task.defer(state.OnEnter, state, self:GetData()))
+    self:_CallMethod(state, true, "OnEnter", self:GetData())
     
     self._CurrentState = newState
 
@@ -582,6 +580,25 @@ function StateMachine:_CallTransitions(state: State, methodName: string, ...: an
     end
 end
 
+--[=[
+    Calls the corresponding method for the given state. (to be cleaned up later)
+
+    @param state State
+    @param methodName string
+    @param shouldDefer boolean?
+    @param ... any
+
+    @private
+
+    @return ()
+]=]
+function StateMachine:_CallMethod(state: State, shouldDefer: boolean, methodName: string, ...: any): ()    
+    local action = shouldDefer and "defer" or "spawn"
+    
+    self._stateTrove:Add(
+        task[action](state[methodName], state, ...)
+    )
+end
 export type RobloxStateMachine = typeof(StateMachine)
 export type State = State.State
 export type Transition = Transition.Transition

--- a/src/StateMachine/init.lua
+++ b/src/StateMachine/init.lua
@@ -253,7 +253,7 @@ function StateMachine.new(initialState: string, states: {State}, initialData: {[
     end
 
     local previousState: State = nil
-    self._trove:Add(RunService.Heartbeat:Connect(function(deltaTime: number)
+    self._trove:Connect(RunService.Heartbeat, function(deltaTime: number)
         if self._Destroyed then
             return
         end
@@ -272,7 +272,7 @@ function StateMachine.new(initialState: string, states: {State}, initialData: {[
         end
 
         self:_CallMethod(state, false, "OnHeartbeat", self:GetData(), deltaTime)
-    end))
+    end)
 
     self._trove:Add(self.StateChanged)
     self._trove:Add(self.DataChanged)

--- a/src/StateMachine/init.lua
+++ b/src/StateMachine/init.lua
@@ -271,7 +271,9 @@ function StateMachine.new(initialState: string, states: {State}, initialData: {[
             return
         end
 
-        task.spawn(state.OnHeartbeat, state, self:GetData(), deltaTime)
+        self._stateTrove:Add(
+            task.spawn(state.OnHeartbeat, state, self:GetData(), deltaTime)
+        )
     end))
 
     self._trove:Add(self.StateChanged)


### PR DESCRIPTION
## 📝Description
Fixed the fact that **previous state** methods can still run, even after swapping states. (#23)

## 🔧Changes
- Added most `state` method calls to be in `_stateTrove`
- Added `_CallMethod` Private method for calling `_stateTrove:Add` and `task.spawn`  on the same line.
- Small Nitpick with `Trove:Add()` usage.

## 👣Next steps
- Doing the same with transitions _(however less problematic)_
- Thinking about maybe moving `_stateTrove` to be in the `State` class.