### PR TITLE
Added feature to support optional priority for transitions

### DIFF
--- a/src/StateMachine/Classes/State.lua
+++ b/src/StateMachine/Classes/State.lua
@@ -25,15 +25,21 @@ State.Name = "" :: string
     @prop Transitions string
     @within State
 
-    A reference for the transitions of this state. This is usually set while creating the state
+    A reference for the transitions of this state. This is usually set while creating the state.
+    Transitions can be defined with an optional priority. If nothing is defined then the default priority 
+    of 0 is used. In this case GoToRed is evaluated first before GoToBlue.
 
     ```lua
     local GoToBlue = require(script.Parent.Parent.Transitions.GoToBlue)
+    local GoToRed = require(script.Parent.Parent.Transitions.GoToRed)
 
     local State = StateMachine.State
 
     local Default = State.new("Default")
-    Default.Transitions = {GoToBlue}
+    Default.Transitions = {
+        {GoToBlue},
+        {GoToRed, 1} 
+        }
     ```
 ]=]
 State.Transitions = {} :: {Transition.Transition}


### PR DESCRIPTION
## 📝Description
Before this change, transitions are treated with random ordering with no guarantee of deterministic behavior. Creating complex State Machine Diagrams results in behavior that may be hard to reproduce. This also prevents extending behaviors with specific use case. 

This change adds `Optional Priorities` Transitions. Transitions are defined like before but can also be defined with an optional `Priority` value. Upon initialization, a list of sorted transitions is built then used when evaluating states. 

This solution is performant and satisfies the original requirement Time Complexity O(1) look up.

How to use: 
In this example we have an Idle State with various Transition Outputs defined by priorities. We define Transitions as usual with an optional priority number. If no priority is defined then the fallback default priority of 0 is used instead.

Note: If a state has multiple Transitions defined with no priority specified the order may vary per runtime (ie `CanFollow` and `RandomEmote` in the example below). _Under the hood each Transition id is randomly generated therefore theres no guarantees on its order._

```luau
local ReplicatedStorage = game.ReplicatedStorage
local RobloxStateMachine = require(ReplicatedStorage.RobloxStateMachine)
local State = RobloxStateMachine.State
local Idle = State.new("Idle")

Idle.Transitions = {
	{require(ReplicatedStorage.AI.Transitions.AttackedByPlayer),3},   -- highest priority, this is always evaluated first
	{require(ReplicatedStorage.AI.Transitions.CanWander), 1},         -- Note: Ordering does not matter as the priority number value is used
	{require(ReplicatedStorage.AI.Transitions.SeesPlayerNearby),2},   
        require(ReplicatedStorage.AI.Transitions.CanFollow),              -- default 0 priority 
        require(ReplicatedStorage.AI.Transitions.RandomEmote),            -- default 0 priority 
}

function Idle:OnEnter(data)
	print("Entered Idle")
end

return Idle
```

## 🔧Changes
- Added method `_BuildTransitionsExecutionOrder` to sort priorities (occurs only once upon init)
- Added support for Priority number value when defining Transitions in a State
- Ensures legacy support when no defined priority is needed

## 👣Next steps
No further steps are necessary